### PR TITLE
Fix Zerion connector detection and center wallet modal options

### DIFF
--- a/web/components/ui/WalletButton.tsx
+++ b/web/components/ui/WalletButton.tsx
@@ -105,7 +105,7 @@ export default function WalletButton({
                     )}
                   </div>
 
-                  <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="flex flex-wrap justify-center gap-3">
                     {connectors.map((connector) => {
                       const envDisabled = connector.type === 'walletConnect' && !walletConnectConfigured;
                       const disabled =
@@ -137,6 +137,7 @@ export default function WalletButton({
                           disabled={(disabled && !isLoading) || envDisabled}
                           className={cn(
                             'group relative overflow-hidden rounded-2xl border border-white/12 bg-white/[0.04] px-4 py-4 text-left transition',
+                            'min-w-[240px] max-w-[320px] flex-1 basis-[240px] sm:basis-[260px] md:basis-[280px]',
                             envDisabled
                               ? 'cursor-not-allowed opacity-60'
                               : disabled && !isLoading


### PR DESCRIPTION
## Summary
- add a Zerion wallet helper that prefers injected providers when WalletConnect is not configured so the extension can connect successfully
- center the wallet connector buttons in the connection modal and give them consistent widths for easier scanning

## Testing
- `npm run lint` *(fails: requires interactive ESLint configuration prompt)*

------
https://chatgpt.com/codex/tasks/task_e_68e01242d8a08325a4fb5566c8375860

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Enhanced Zerion wallet integration: auto-detects injected provider, correctly shows/hides availability, marks as installed when present, and connects via injected provider with fallback preserved.

- Style
  - Updated wallet selection layout to a responsive flex-based design with consistent button sizing and wrapping, improving readability across screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->