### PR TITLE
Fix Zerion provider typing to restore build

### DIFF
--- a/web/components/providers.tsx
+++ b/web/components/providers.tsx
@@ -1,10 +1,11 @@
 'use client';
 
 import React from 'react';
-import { WagmiProvider } from 'wagmi';
+import { WagmiProvider, createConnector } from 'wagmi';
 import { base, baseSepolia } from 'wagmi/chains';
-import { http } from 'viem';
+import { http, type EIP1193Provider } from 'viem';
 import { getDefaultConfig, RainbowKitProvider, darkTheme, type WalletList } from '@rainbow-me/rainbowkit';
+import { injected } from 'wagmi/connectors';
 import {
   argentWallet,
   backpackWallet,
@@ -51,6 +52,93 @@ if (RPC_SEPOLIA) {
 // --- Wagmi/RainbowKit config (v2 style) ---
 const chains = [base, baseSepolia] as const;
 
+type ZerionCandidate = (EIP1193Provider & {
+  isZerion?: true;
+  provider?: ZerionCandidate;
+}) | undefined;
+
+function extractZerionProvider(candidate: unknown): ZerionCandidate {
+  if (!candidate || typeof candidate !== 'object') return undefined;
+  const record = candidate as ZerionCandidate;
+  if (!record) return undefined;
+  if (record.isZerion) return record;
+  if (record.provider && record.provider.isZerion) return record.provider;
+  return undefined;
+}
+
+function getZerionInjectedProvider(): ZerionCandidate {
+  if (typeof window === 'undefined') return undefined;
+  const win = window as typeof window & {
+    zerionWallet?: {
+      ethereum?: ZerionCandidate;
+      provider?: ZerionCandidate;
+    };
+    ethereum?: ZerionCandidate & {
+      providers?: ZerionCandidate[];
+    };
+  };
+
+  const providers = win.ethereum?.providers;
+  if (Array.isArray(providers)) {
+    for (const provider of providers) {
+      const extracted = extractZerionProvider(provider);
+      if (extracted) return extracted;
+    }
+  }
+
+  const fallbacks: (ZerionCandidate | undefined)[] = [
+    win.ethereum,
+    win.zerionWallet?.ethereum,
+    win.zerionWallet?.provider,
+    win.zerionWallet as ZerionCandidate,
+  ];
+
+  for (const candidate of fallbacks) {
+    const extracted = extractZerionProvider(candidate);
+    if (extracted) return extracted;
+  }
+
+  return undefined;
+}
+
+const patchedZerionWallet: (typeof zerionWallet) = (options) => {
+  const wallet = zerionWallet(options);
+
+  if (walletConnectConfigured) {
+    return wallet;
+  }
+
+  const baseHidden = wallet.hidden;
+
+  return {
+    ...wallet,
+    hidden: () => {
+      if (baseHidden?.()) return true;
+      return typeof window === 'undefined' ? true : !getZerionInjectedProvider();
+    },
+    installed: typeof window === 'undefined' ? false : Boolean(getZerionInjectedProvider()),
+    createConnector: (walletDetails) => {
+      const provider = getZerionInjectedProvider();
+      if (!provider) {
+        return wallet.createConnector(walletDetails);
+      }
+
+      const injectedConfig = {
+        target: () => ({
+          id: walletDetails.rkDetails.id,
+          name: walletDetails.rkDetails.name,
+          provider: () => provider,
+        }),
+      } as const;
+
+      return createConnector((config) => ({
+        ...injected(injectedConfig)(config),
+        ...walletDetails,
+      }));
+    },
+  };
+};
+
 const walletGroups = [
   {
     groupName: 'Popular',
@@ -59,7 +147,7 @@ const walletGroups = [
       metaMaskWallet,
       coinbaseWallet,
       ...(walletConnectConfigured ? [walletConnectWallet] : []),
-      zerionWallet,
+      patchedZerionWallet,
       rabbyWallet,
     ],
   },

--- a/web/components/ui/WalletButton.tsx
+++ b/web/components/ui/WalletButton.tsx
@@ -105,7 +105,7 @@ export default function WalletButton({
                     )}
                   </div>
 
-                  <div className="grid gap-3 sm:grid-cols-2">
+                  <div className="flex flex-wrap justify-center gap-3">
                     {connectors.map((connector) => {
                       const envDisabled = connector.type === 'walletConnect' && !walletConnectConfigured;
                       const disabled =
@@ -137,6 +137,7 @@ export default function WalletButton({
                           disabled={(disabled && !isLoading) || envDisabled}
                           className={cn(
                             'group relative overflow-hidden rounded-2xl border border-white/12 bg-white/[0.04] px-4 py-4 text-left transition',
+                            'min-w-[240px] max-w-[320px] flex-1 basis-[240px] sm:basis-[260px] md:basis-[280px]',
                             envDisabled
                               ? 'cursor-not-allowed opacity-60'
                               : disabled && !isLoading


### PR DESCRIPTION
## Summary
- tighten the Zerion injected provider helper typings so it matches the wagmi injected connector expectations
- wrap the custom injected target provider getter in a function to satisfy wagmi's Target type and keep the Zerion extension available without WalletConnect

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68e01242d8a08325a4fb5566c8375860

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Added seamless Zerion wallet support with automatic detection of injected providers.
  * Ensures Zerion is used when available while preserving existing wallet behavior as fallback.

* Style
  * Updated wallet connector list to a flexible, wrapping layout for better responsiveness.
  * Improved connector button sizing and spacing across breakpoints for more consistent alignment.
  * Enhances readability and usability of the wallet selection UI on various screen sizes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->